### PR TITLE
don't configure dependencies in exec-maven-plugin

### DIFF
--- a/greetings-tycho/2.26.0/org.xtext.example.mydsl/META-INF/MANIFEST.MF
+++ b/greetings-tycho/2.26.0/org.xtext.example.mydsl/META-INF/MANIFEST.MF
@@ -7,6 +7,9 @@ Bundle-SymbolicName: org.xtext.example.mydsl; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
- org.eclipse.equinox.common;bundle-version="3.5.0"
+ org.eclipse.equinox.common;bundle-version="3.5.0",
+ org.eclipse.emf.mwe2.launch;resolution:=optional,
+ org.eclipse.emf.mwe2.lib;resolution:=optional,
+ org.eclipse.xtext.generator;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.xtext.example.mydsl

--- a/greetings-tycho/2.26.0/org.xtext.example.mydsl/pom.xml
+++ b/greetings-tycho/2.26.0/org.xtext.example.mydsl/pom.xml
@@ -33,36 +33,8 @@
 						<argument>rootPath=/${project.basedir}/..</argument>
 					</arguments>
 					<classpathScope>compile</classpathScope>
-					<includePluginDependencies>true</includePluginDependencies>
 					<cleanupDaemonThreads>false</cleanupDaemonThreads><!-- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=475098#c3 -->
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.eclipse.emf</groupId>
-						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>${mwe2Version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.xtext</groupId>
-						<artifactId>org.eclipse.xtext.common.types</artifactId>
-						<version>${xtextVersion}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.xtext</groupId>
-						<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
-						<version>${xtextVersion}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.xtext</groupId>
-						<artifactId>org.eclipse.xtext.xbase</artifactId>
-						<version>${xtextVersion}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.xtext</groupId>
-						<artifactId>xtext-antlr-generator</artifactId>
-						<version>2.1.1</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>


### PR DESCRIPTION
That's related to https://github.com/eclipse/xtext/issues/1976

The idea is NOT to specify dependencies in the `exec-maven-plugin` but to let it take it from the target platform (so we have optional dependencies in the MANIFEST.MF, as it used to be in the past, IIRC). This way, we don't get unwanted new transitive deps when running `exec-maven-plugin`.

Note that currently `.antlr-generator-3.2.0-patch.jar` is downloaded, but I think it's enough to make it available in the TP as well (and as an optional dep in the MANIFEST.MF)