### PR TITLE
[eclipse/xtext#2721] use maven gson instead of orbit gson

### DIFF
--- a/greetings-tycho/2.32.0-J11/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
+++ b/greetings-tycho/2.32.0-J11/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
@@ -19,7 +19,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/nightly/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.10.1.v20230109-0753"/>
+			<unit id="com.google.gson" version="2.10.1"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
 			<unit id="javax.inject" version="1.0.0.v20220405-0441"/>

--- a/greetings-tycho/2.32.0/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
+++ b/greetings-tycho/2.32.0/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
@@ -19,7 +19,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/nightly/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.10.1.v20230109-0753"/>
+			<unit id="com.google.gson" version="2.10.1"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
 			<unit id="javax.inject" version="1.0.0.v20220405-0441"/>

--- a/integrationtests/org.eclipse.xtext.integrationtests.target/org.eclipse.xtext.integrationtests.target.target
+++ b/integrationtests/org.eclipse.xtext.integrationtests.target/org.eclipse.xtext.integrationtests.target.target
@@ -23,8 +23,8 @@
     </location>
 
    	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-   		<unit id="com.google.gson" version="2.10.1.v20230109-0753"/>
-   		<unit id="com.google.gson.source" version="2.10.1.v20230109-0753"/>
+   		<unit id="com.google.gson" version="2.10.1"/>
+   		<unit id="com.google.gson.source" version="2.10.1"/>
 		<unit id="com.google.guava" version="32.0.1.jre"/>
 		<unit id="com.google.guava.source" version="32.0.1.jre"/>
 		<unit id="com.google.guava.failureaccess" version="1.0.1"/>


### PR DESCRIPTION
[eclipse/xtext#2721] use maven gson instead of orbit gson