### PR TITLE
Show stacktrace in junitView().isTestrunErrorFree() if it fails

### DIFF
--- a/integrationtests/org.eclipse.xtext.swtbot.testing/src/org/eclipse/xtext/swtbot/testing/api/JUnitViewAPI.java
+++ b/integrationtests/org.eclipse.xtext.swtbot.testing/src/org/eclipse/xtext/swtbot/testing/api/JUnitViewAPI.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.swtbot.testing.api;
 
 import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.eclipse.xtext.swtbot.testing.internal.XtextSWTBotShell;
@@ -32,8 +33,29 @@ public class JUnitViewAPI {
 		boolean result = atLeastOneTestIsRun() && errorCount() == 0 && failureCount() == 0;
 		System.out.println("Check if test run is error free: '" + result + "'");
 		if (!result) {
-			for (SWTBotTreeItem item : view.bot().tree().getAllItems())
-				System.out.println("  " + item.getText());
+			// for each test case in the view
+			for (SWTBotTreeItem testCase : view.bot().tree().getAllItems()) {
+				SWTBotTreeItem[] items = testCase.getItems();
+				// for each test in the test case
+				for (SWTBotTreeItem test : items) {
+					// select it
+					test.select();
+					SWTBotTable failureTrace = view.bot().table();
+					int rowCount = failureTrace.rowCount();
+					// and see whether the "Failure Trace" table gets populated;
+					// if it is, that test has failed
+					if (rowCount > 0) {
+						System.out.println();
+						System.out.println("FAILED TEST: " + test.getText());
+						System.out.println("FAILURE TRACE:");
+						for (int r = 0; r < rowCount; r++) {
+							System.out.println(failureTrace.getTableItem(r).getText());
+						}
+						System.out.println("END FAILURE TRACE of: " + test.getText());
+					}
+				}
+			}
+			System.out.println();
 		}
 		return result;
 	}

--- a/integrationtests/org.eclipse.xtext.swtbot.testing/src/org/eclipse/xtext/swtbot/testing/api/JUnitViewAPI.java
+++ b/integrationtests/org.eclipse.xtext.swtbot.testing/src/org/eclipse/xtext/swtbot/testing/api/JUnitViewAPI.java
@@ -35,6 +35,8 @@ public class JUnitViewAPI {
 		if (!result) {
 			// for each test case in the view
 			for (SWTBotTreeItem testCase : view.bot().tree().getAllItems()) {
+				System.out.println();
+				System.out.println("TEST CASE: " + testCase.getText());
 				SWTBotTreeItem[] items = testCase.getItems();
 				// for each test in the test case
 				for (SWTBotTreeItem test : items) {
@@ -42,16 +44,18 @@ public class JUnitViewAPI {
 					test.select();
 					SWTBotTable failureTrace = view.bot().table();
 					int rowCount = failureTrace.rowCount();
+					String testText = test.getText();
 					// and see whether the "Failure Trace" table gets populated;
 					// if it is, that test has failed
-					if (rowCount > 0) {
+					if (rowCount > 0 && !testText.isBlank()) {
+						// sometimes the testText is empty and we get it at the next iteration
 						System.out.println();
-						System.out.println("FAILED TEST: " + test.getText());
+						System.out.println("FAILED TEST: " + testText);
 						System.out.println("FAILURE TRACE:");
 						for (int r = 0; r < rowCount; r++) {
 							System.out.println(failureTrace.getTableItem(r).getText());
 						}
-						System.out.println("END FAILURE TRACE of: " + test.getText());
+						System.out.println("END FAILURE TRACE of: " + testText);
 					}
 				}
 			}


### PR DESCRIPTION
Closes #459 

In case tests failed when run from SWTBot, the corresponding failure trace is printed on standard output.

For example, I introduced some failing tests in the Domainmodel examples' tests (2 in validator test, 1 in in xbase integration test and I modified the expected string in compiler test), and on the console I see:

```
Check if test run is error free: 'false'

TEST CASE: org.eclipse.xtext.example.domainmodel.tests.FormatterTest [Runner: JUnit 4] (1.362 s)

TEST CASE: org.eclipse.xtext.example.domainmodel.tests.CompilerTest [Runner: JUnit 4] (0.634 s)

FAILED TEST: compareGeneratedJava (0.036 s)
FAILURE TRACE:
org.junit.ComparisonFailure: expected:<...l.ToStringBuilder;

[// I'M NOT THERE!!!

]@SuppressWarnings("a...> but was:<...l.ToStringBuilder;

[]@SuppressWarnings("a...>
 at org.junit.Assert.assertEquals(Assert.java:117)
 at org.eclipse.xtext.example.domainmodel.tests.CompilerTest.lambda$3(CompilerTest.java:237)
 at org.eclipse.xtext.xbase.testing.CompilationTestHelper.compile(CompilationTestHelper.java:253)
 at org.eclipse.xtext.xbase.testing.CompilationTestHelper.compile(CompilationTestHelper.java:202)
 at org.eclipse.xtext.example.domainmodel.tests.CompilerTest.compareGeneratedJava(CompilerTest.java:239)
 at org.eclipse.xtext.testing.XtextRunner$1.evaluate(XtextRunner.java:50)
END FAILURE TRACE of: compareGeneratedJava (0.036 s)

TEST CASE: org.eclipse.xtext.example.domainmodel.tests.ValidationTests [Runner: JUnit 4] (0.505 s)

FAILED TEST: testWithFailure (0.001 s)
FAILURE TRACE:
java.lang.AssertionError
 at org.junit.Assert.fail(Assert.java:87)
 at org.eclipse.xtext.example.domainmodel.tests.ValidationTests.testWithFailure(ValidationTests.java:439)
 at org.eclipse.xtext.testing.XtextRunner$1.evaluate(XtextRunner.java:50)
END FAILURE TRACE of: testWithFailure (0.001 s)

FAILED TEST: testWithError (0.000 s)
FAILURE TRACE:
java.lang.IllegalArgumentException: bang
 at org.eclipse.xtext.example.domainmodel.tests.ValidationTests.testWithError(ValidationTests.java:444)
 at org.eclipse.xtext.testing.XtextRunner$1.evaluate(XtextRunner.java:50)
END FAILURE TRACE of: testWithError (0.000 s)

TEST CASE: org.eclipse.xtext.example.domainmodel.tests.XbaseIntegrationTest [Runner: JUnit 4] (16.099 s)

FAILED TEST: failedTestInXbaseIntegration (0.001 s)
FAILURE TRACE:
java.lang.AssertionError
 at org.junit.Assert.fail(Assert.java:87)
 at org.eclipse.xtext.example.domainmodel.tests.XbaseIntegrationTest.failedTestInXbaseIntegration(XbaseIntegrationTest.java:68)
 at org.eclipse.xtext.testing.XtextRunner$1.evaluate(XtextRunner.java:50)
END FAILURE TRACE of: failedTestInXbaseIntegration (0.001 s)

TEST CASE: org.eclipse.xtext.example.domainmodel.tests.OrganizeImportsTest [Runner: JUnit 4] (0.414 s)

TEST CASE: org.eclipse.xtext.example.domainmodel.tests.DomainmodelParsingTest [Runner: JUnit 4] (0.047 s)

```